### PR TITLE
bug fix:  install fails for latest niftyreg v1.5.69

### DIFF
--- a/niftypet/ninst/install_tools.py
+++ b/niftypet/ninst/install_tools.py
@@ -53,7 +53,7 @@ sha1_reg = "gcc9-omp-fix"
 # 'f673b7837c0824f55dedb1534b32b55bf68a2823'
 # '6bf84b492050a4b9a93431209babeab9bc8f14da'
 # '62af1ca6777379316669b6934889c19863eaa708'
-reg_ver = "1.5.68"
+reg_ver = "1.5"
 
 # dcm2niix
 repo_dcm = "https://github.com/rordenlab/dcm2niix"


### PR DESCRIPTION
Currently, I'm unable to install NiftyPET for python3.  The install error is thrown at install_tools line 447, but check_version() looks for a substring so requiring major revision 1.5 would a quick fix.  The alternative of finding niftyreg v1.5.68 appears quite difficult.

Please forward best regards to Pawel.